### PR TITLE
Sample Groovy script

### DIFF
--- a/code-examples/Groovy/send_sms.groovy
+++ b/code-examples/Groovy/send_sms.groovy
@@ -1,0 +1,25 @@
+import org.apache.http.client.fluent.Content
+import org.apache.http.client.fluent.Form
+import org.apache.http.client.fluent.Request
+
+@Grab(group = 'org.apache.httpcomponents', module = 'fluent-hc', version = '4.5.2')
+
+def sendSms(String from, String to, String message) {
+	def user = "API_USERNAME" //TODO Change it!
+	def password = "API_PASSWORD" //TODO Change it!
+	def credentials = "${user}:${password}"
+
+	Content content = Request.Post("https://api.46elks.com/a1/SMS")
+			.addHeader("Authorization", "Basic " + credentials.bytes.encodeBase64().toString())
+			.addHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+			.bodyForm(Form.form()
+			.add("message", message)
+			.add("to", to)
+			.add("from", from)
+			.build())
+
+			.execute().returnContent()
+}
+
+Content content = sendSms("Someone", "+34617112338", "Freshly brewed coffee is tasteful!")
+System.out.println(content)


### PR DESCRIPTION
This is a simple Groovy script which uses Apache HttpClient Fluent API (https://hc.apache.org/httpcomponents-client-ga/tutorial/html/fluent.html) to send an SMS. 

Tested on Groovy 2.4.x, to run it just change the API username and password, from, to and message and execute `groovy send_sms.groovy`