### PR TITLE
Rewrote the Haskell example a bit.

### DIFF
--- a/code-examples/haskell/send_sms.hs
+++ b/code-examples/haskell/send_sms.hs
@@ -3,64 +3,73 @@
 -- Sending SMS using Haskell and the 46elks API
 --
 {-# LANGUAGE OverloadedStrings #-}
-import Data.Aeson ((.:), decode, FromJSON(..), Value(..))
+
+import Data.Aeson (FromJSON, parseJSON, withObject, (.:))
 import Data.ByteString (ByteString)
-import Data.HashMap.Strict as HM
-import Network.HTTP.Conduit (newManager
-                            , tlsManagerSettings
-                            , parseUrl
-                            , httpLbs
-                            , urlEncodedBody
-                            , responseBody)
-import Text.Printf (printf)
+import Data.ByteString.Char8 (pack)
+import Data.Monoid ((<>))
+import Network.HTTP.Simple ( Request, parseRequest, httpJSON
+                           , setRequestBasicAuth, setRequestBodyURLEncoded
+                           , setRequestMethod, getResponseBody)
 
--- Information about how to porse the response code from 46elks API
-data Status = Status { from :: String
-                     , to :: String
-                     , message :: String
-                     } deriving (Show)
+-- | SMS data type for 46elks API, the compiler will automatically
+-- derive instances for transforming an SMS to a JSON object.
+data SMS = SMS { smsTo :: String
+               , smsFrom :: String
+               , smsMessage :: String
+               } deriving (Show)
 
--- Parse response code from the 46elks API into a Status object
-instance FromJSON Status where
-    parseJSON (Object v) =
-        Status <$>
-        (v .: "from") <*>
-        (v .: "to") <*>
-        (v .: "message")
+type Username = ByteString
+type Secret   = ByteString
+
+-- | How to parse the status of a sent SMS from a 46elks JSON response
+instance FromJSON SMS where
+  parseJSON = withObject "status" $ \o ->
+    SMS <$> o  .: "to" <*> o .: "from" <*> o .: "message"
+
+-- | Prepares a SMS for inclusion in a URLEncoded POST body.
+urlEncodeSMS :: SMS -> [(ByteString, ByteString)]
+urlEncodeSMS (SMS to from message) = [ ("to", pack to)
+                                     , ("from", pack from)
+                                     , ("message", pack message) ]
 
 -- Your 46elks API key
-username :: String
+username :: Username
 username = "YOUR_API_USER_IDENTIFIER"
 
 -- Your 46elks API secret
-secret :: String
+secret :: Secret
 secret = "YOUR_API_SECRET"
 
 -- Format the API URL to use for the request
-apiurl :: String
-apiurl = printf "https://%s:%s@api.46elks.com/a1/SMS" username secret
+apiUrl :: String
+apiUrl = "https://api.46elks.com/a1/SMS"
 
-prepare_sms :: ByteString -> ByteString -> ByteString -> [(ByteString, ByteString)]
-prepare_sms to from message =
-    [("to", to), ("from", from), ("message", message)]
+-- | Prepares a request by making it a POST request, with JSON
+-- encoding and Basic authentication.
+prepareRequest :: SMS -> Request -> Request
+prepareRequest sms req =
+  setRequestBodyURLEncoded (urlEncodeSMS sms)
+  . setRequestMethod "POST"
+  . setRequestBasicAuth username secret
+  $ req
 
+-- | Sends an sms to a number through 463elks api.
 send_sms :: IO ()
 send_sms = do
     -- Send SMS POST to 46elks
-    let sms_content = prepare_sms "+46700000000" "Haskelk" "Hello from Haskell"
-    manager <- newManager tlsManagerSettings
-    request' <- parseUrl apiurl
-    let request = urlEncodedBody sms_content request'
-    result <- httpLbs request manager
+    let sms = SMS "+46700000000" "Haskelk" "Hello from Haskell"
+    request <- prepareRequest sms <$> parseRequest apiUrl
+
     -- Parse the result for pretty printing
-    let resultStr = responseBody result
-    let (Just (Object json)) = decode resultStr :: Maybe Value
-    let (Just (String from)) = HM.lookup "from" json
-    let (Just (String to)) = HM.lookup "to" json
-    let (Just (String message)) = HM.lookup "message" json
-    -- Pretty print
-    printf "Sent \"%s\" from %s to %s\n" message from to
+    body <- getResponseBody <$> httpJSON request
+
+    -- Print response message
+    putStrLn $ responseString (smsMessage body) (smsFrom body) (smsTo body)
+
+      where responseString :: String -> String -> String -> String
+            responseString msg sender recipient =
+              "Sent \"" <> msg <> "\" from " <> sender <> " to " <> recipient
 
 main :: IO ()
 main = send_sms
-

--- a/code-examples/haskell/send_sms.hs
+++ b/code-examples/haskell/send_sms.hs
@@ -54,7 +54,7 @@ prepareRequest sms req =
   . setRequestBasicAuth username secret
   $ req
 
--- | Sends an sms to a number through 463elks api.
+-- | Sends a sms to a number through 46elks api.
 send_sms :: IO ()
 send_sms = do
     -- Send SMS POST to 46elks


### PR DESCRIPTION
I rewrote the Haskell example in a more "Haskell"-ish style.

The major difference/contribution I've made is to make the SMS type an instance of FromJSON type class which allows us to automatically parse JSON values to SMS values (and this is done by the httpJSON function).

The prepare_sms and urlEncodeSMS functions really look similar and that is because they are. The code below went through a couple of iterations and I didn't realise that I've recreated a function that was originally present before now..