### PR TITLE
Fix errors in node.js call example

### DIFF
--- a/code-examples/Node/node-calls.js
+++ b/code-examples/Node/node-calls.js
@@ -21,7 +21,6 @@ var options = {
   }
 };
 
-
 callback = function(response) {
   var str = ''
   response.on('data', function (chunk) {

--- a/code-examples/Node/node-calls.js
+++ b/code-examples/Node/node-calls.js
@@ -9,7 +9,7 @@ var postFields = {
   voice_start: '{"connect":"+461890510"}'
   }
 
-var key = new Buffer(uusername + ':' + password..toString('base64');
+var key = new Buffer(username + ':' + password).toString('base64');
 var postData = querystring.stringify(postFields);
 
 var options = {
@@ -18,17 +18,9 @@ var options = {
   method:   'POST',
   headers:  {
     'Authorization': 'Basic ' + key
-    }
-  };
+  }
+};
 
-// Start the web request.
-var request = https.request(options, callback);
-
-// Send the real data away to the server.
-request.write(postData);
-
-// Finish sending the request.
-request.end();
 
 callback = function(response) {
   var str = ''
@@ -40,3 +32,12 @@ callback = function(response) {
     console.log(str);
   });
 }
+
+// Start the web request.
+var request = https.request(options, callback);
+
+// Send the real data away to the server.
+request.write(postData);
+
+// Finish sending the request.
+request.end();


### PR DESCRIPTION
Fix syntax error and wrongly named variables.
And move callback initialization below usage.